### PR TITLE
fix: rm app date on home page & update text

### DIFF
--- a/_includes/home/what-to-expect.html
+++ b/_includes/home/what-to-expect.html
@@ -49,7 +49,7 @@
                             <h2 class="h4 margin-0">Application Process</h2>
                         </div>
                         <div class="usa-card__body">
-                            <p>Applications are continuously reviewed and accepted until applications close on April 30, 2024. </p>
+                            <p>Applications are continuously reviewed and accepted until the end of the application cycle.</p>
                         </div>
                     </div>
                 </div>

--- a/_site/index.html
+++ b/_site/index.html
@@ -441,7 +441,7 @@
                             <h2 class="h4 margin-0">Application Process</h2>
                         </div>
                         <div class="usa-card__body">
-                            <p>Applications are continuously reviewed and accepted until applications close on April 30, 2024. </p>
+                            <p>Applications are continuously reviewed and accepted until the end of the application cycle.</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Bug Fix
- [x] Hot Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Rm app date on home page under "What to Expect" / "Application Process" and change text to "Applications are continuously reviewed and accepted until the end of the application cycle."

## Related Tickets & Documents
- Monday Task #6554969765
- https://blackberg-group.monday.com/boards/1931719392/pulses/6554969765

## QA Instructions, Screenshots, Recordings
Jason found another ref to date on home. Rm app date on home page under "What to Expect" / "Application Process" and change text to "Applications are continuously reviewed and accepted until the end of the application cycle."

### UI accessibility checklist
_If your PR includes UI changes, please utilize this checklist:_
- [ ] Semantic HTML implemented?
- [ ] Keyboard operability supported?
- [ ] Checked with [Google Lighthouse](https://developer.chrome.com/docs/lighthouse/overview) and addressed `Critical` and `Serious` issues?
- [ ] Color contrast tested?

## Are there any post deployment tasks we need to perform?
- Add GA code on production
- Proper meta tags utilized

## Changed Files in this Pull Request ##
- _includes/home/what-to-expect.html
 - _site/index.html